### PR TITLE
Support prefixes !, ~, !~

### DIFF
--- a/corpus/DZ4/dist.ini
+++ b/corpus/DZ4/dist.ini
@@ -1,0 +1,18 @@
+name    = DZ4
+version = 0.001
+author  = E. Xavier Ample <example@example.org>
+license = Perl_5
+copyright_holder = E. Xavier Ample
+
+[@Filter]
+bundle = @FakeClassic
+remove = ConfirmRelease
+remove = FakeRelease
+
+[ModuleBuild]
+[OSPrereqs / !MSWin32]
+Proc::ProcessTable = 0.50
+[OSPrereqs / ~foo]
+Acme::One = 0.01
+[OSPrereqs / !~bar]
+Acme::Two = 0.02

--- a/corpus/DZ4/lib/DZ4.pm
+++ b/corpus/DZ4/lib/DZ4.pm
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+package DZ4;
+# ABSTRACT: this is a sample package for testing Dist::Zilla;
+
+sub main {
+  return 1;
+}
+
+1;

--- a/lib/Dist/Zilla/Plugin/OSPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/OSPrereqs.pm
@@ -110,7 +110,16 @@ sub setup_installer {
 
   my $content = $build_script->content;
 
-  my $prereq_str = "if ( \$^O eq '$os' ) {\n";
+  my $prereq_str;
+  if ($os =~ /^!~(.+)/) {
+    $prereq_str = "if ( \$^O !~ /$1/i ) {\n";
+  } elsif ($os =~ /^!(.+)/) {
+    $prereq_str = "if ( \$^O ne '$1' ) {\n";
+  } elsif ($os =~ /^~(.+)/) {
+    $prereq_str = "if ( \$^O =~ /$1/i ) {\n";
+  } else {
+    $prereq_str = "if ( \$^O eq '$os' ) {\n";
+  }
   my $prereq_hash = $self->_prereq;
   for my $k ( sort keys %$prereq_hash ) {
     my $v = $prereq_hash->{$k};
@@ -145,6 +154,21 @@ In your dist.ini:
 
   [OSPrereqs / MSWin32]
   Win32API::File = 0.11
+
+Some prefixes are recognized, i.e. C<!> (not), C<~> (regex match), C<!~> (regex
+non-match). Regex matches are done case-insensitively for convenience:
+
+  ; require on non-Win32 system
+  [OSPrereqs / !MSWin32]
+  Proc::ProcessTable = 0.50
+
+  ; require on BSD
+  [OSPrereqs / ~bsd]
+  BSD::Resource=0
+
+  ; require on non-Windows system
+  [OSPrereqs / !win]
+  Proc::ProcessTable = 0.50
 
 = DESCRIPTION
 

--- a/t/osprereqs-prefix.t
+++ b/t/osprereqs-prefix.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use Test::More 0.88;
+use Path::Class;
+
+use Test::DZil;
+
+my $tzil = Builder->from_config(
+  { dist_root => 'corpus/DZ4' },
+);
+
+$tzil->build;
+
+my $contents = $tzil->slurp_file('build/Makefile.PL');
+
+{
+  my $conditional = q|if ( $^O ne 'MSWin32' ) {|;
+  my $prereq = q|$WriteMakefileArgs{PREREQ_PM}{'Proc::ProcessTable'} = '0.50'|;
+  like($contents, qr/\Q$conditional\E.*?\Q$prereq\E.*?^\}/ms, "saw !prefix conditional");
+}
+
+{
+  my $conditional = q|if ( $^O =~ /foo/i ) {|;
+  my $prereq = q|$WriteMakefileArgs{PREREQ_PM}{'Acme::One'} = '0.01'|;
+  like($contents, qr/\Q$conditional\E.*?\Q$prereq\E.*?^\}/ms, "saw ~prefix conditional");
+}
+
+{
+  my $conditional = q|if ( $^O !~ /bar/i ) {|;
+  my $prereq = q|$WriteMakefileArgs{PREREQ_PM}{'Acme::Two'} = '0.02'|;
+  like($contents, qr/\Q$conditional\E.*?\Q$prereq\E.*?^\}/ms, "saw !~prefix conditional");
+}
+
+done_testing;
+


### PR DESCRIPTION
Hi David,

Thanks for OSPrereqs. Sure this plugin is a hack, but a convenient hack nevertheless. This commit increases the convenience factor by allowing expressing "require only on OS'es other than this one" and "require on OS'es (not) matching this pattern".
